### PR TITLE
Fix IngesterServer injection

### DIFF
--- a/apps/ingester/src/presentation/server.ts
+++ b/apps/ingester/src/presentation/server.ts
@@ -43,10 +43,9 @@ export class IngesterServer {
   }
   static inject = [
     "loggerManager",
-    "dashboardRouter",
     "metricsRouter",
+    "dashboardRouter",
     "ingester",
-    "metricReporter",
   ] as const;
 
   start() {


### PR DESCRIPTION
## Summary
- remove unused `metricReporter` from IngesterServer injection list
- keep DI order aligned with constructor

## Testing
- `pnpm lint`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68402ef1c64c8328bbefcc7378eeaffc