### PR TITLE
likeレコードのインデックス機能を実装

### DIFF
--- a/apps/worker/src/application/interfaces/repositories/like-repository.ts
+++ b/apps/worker/src/application/interfaces/repositories/like-repository.ts
@@ -1,0 +1,5 @@
+import type { Like, TransactionContext } from "@repo/common/domain";
+
+export interface ILikeRepository {
+  upsert: (params: { ctx: TransactionContext; like: Like }) => Promise<void>;
+}

--- a/apps/worker/src/application/services/indexer/index-commit-service.ts
+++ b/apps/worker/src/application/services/indexer/index-commit-service.ts
@@ -11,6 +11,7 @@ import type { IRecordRepository } from "../../interfaces/repositories/record-rep
 import type { IIndexCollectionService } from "../../interfaces/services/index-collection-service.js";
 import type { IndexActorService } from "./index-actor-service.js";
 import type { IndexFollowService } from "./index-follow-service.js";
+import type { IndexLikeService } from "./index-like-service.js";
 import type { IndexPostService } from "./index-post-service.js";
 import type { IndexProfileService } from "./index-profile-service.js";
 import type { IndexSubscriptionService } from "./index-subscription-service.js";
@@ -33,12 +34,14 @@ export class IndexCommitService {
     indexPostService: IndexPostService,
     indexProfileService: IndexProfileService,
     indexFollowService: IndexFollowService,
+    indexLikeService: IndexLikeService,
     indexSubscriptionService: IndexSubscriptionService,
   ) {
     this.services = {
       "app.bsky.feed.post": indexPostService,
       "app.bsky.actor.profile": indexProfileService,
       "app.bsky.graph.follow": indexFollowService,
+      "app.bsky.feed.like": indexLikeService,
       "dev.mkizka.test.subscription": indexSubscriptionService,
     };
   }
@@ -48,6 +51,7 @@ export class IndexCommitService {
     "indexPostService",
     "indexProfileService",
     "indexFollowService",
+    "indexLikeService",
     "indexSubscriptionService",
   ] as const;
 

--- a/apps/worker/src/application/services/indexer/index-like-service.ts
+++ b/apps/worker/src/application/services/indexer/index-like-service.ts
@@ -1,0 +1,45 @@
+import type { Record, TransactionContext } from "@repo/common/domain";
+import { Like } from "@repo/common/domain";
+
+import type { ILikeRepository } from "../../interfaces/repositories/like-repository.js";
+import type { IPostRepository } from "../../interfaces/repositories/post-repository.js";
+import type { ISubscriptionRepository } from "../../interfaces/repositories/subscription-repository.js";
+import type { IIndexCollectionService } from "../../interfaces/services/index-collection-service.js";
+
+export class IndexLikeService implements IIndexCollectionService {
+  constructor(
+    private readonly likeRepository: ILikeRepository,
+    private readonly postRepository: IPostRepository,
+    private readonly subscriptionRepository: ISubscriptionRepository,
+  ) {}
+  static inject = [
+    "likeRepository",
+    "postRepository",
+    "subscriptionRepository",
+  ] as const;
+
+  async upsert({ ctx, record }: { ctx: TransactionContext; record: Record }) {
+    const like = Like.from(record);
+    await this.likeRepository.upsert({ ctx, like });
+  }
+
+  async shouldSave({
+    ctx,
+    record,
+  }: {
+    ctx: TransactionContext;
+    record: Record;
+  }): Promise<boolean> {
+    const like = Like.from(record);
+
+    // いいねしたユーザーがsubscriberなら保存
+    const isLikerSubscriber =
+      await this.subscriptionRepository.hasAnySubscriber(ctx, [like.actorDid]);
+    if (isLikerSubscriber) {
+      return true;
+    }
+
+    // いいねされた投稿がDBに存在すれば保存（投稿の保存ルールを通った投稿のみDBにあるため）
+    return this.postRepository.existsAny(ctx, [like.subjectUri.toString()]);
+  }
+}

--- a/apps/worker/src/infrastructure/like-repository.ts
+++ b/apps/worker/src/infrastructure/like-repository.ts
@@ -1,0 +1,26 @@
+import type { Like, TransactionContext } from "@repo/common/domain";
+import { schema } from "@repo/db";
+
+import type { ILikeRepository } from "../application/interfaces/repositories/like-repository.js";
+
+export class LikeRepository implements ILikeRepository {
+  async upsert({ ctx, like }: { ctx: TransactionContext; like: Like }) {
+    const data = {
+      cid: like.cid,
+      actorDid: like.actorDid,
+      subjectUri: like.subjectUri.toString(),
+      subjectCid: like.subjectCid,
+      createdAt: like.createdAt,
+    };
+    await ctx.db
+      .insert(schema.likes)
+      .values({
+        uri: like.uri.toString(),
+        ...data,
+      })
+      .onConflictDoUpdate({
+        target: schema.likes.uri,
+        set: data,
+      });
+  }
+}

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -13,6 +13,7 @@ import { createInjector } from "typed-inject";
 import { IndexActorService } from "./application/services/indexer/index-actor-service.js";
 import { IndexCommitService } from "./application/services/indexer/index-commit-service.js";
 import { IndexFollowService } from "./application/services/indexer/index-follow-service.js";
+import { IndexLikeService } from "./application/services/indexer/index-like-service.js";
 import { IndexPostService } from "./application/services/indexer/index-post-service.js";
 import { IndexProfileService } from "./application/services/indexer/index-profile-service.js";
 import { IndexSubscriptionService } from "./application/services/indexer/index-subscription-service.js";
@@ -27,6 +28,7 @@ import { IndexCommitUseCase } from "./application/use-cases/commit/index-commit-
 import { UpsertIdentityUseCase } from "./application/use-cases/identity/upsert-identity-use-case.js";
 import { ActorRepository } from "./infrastructure/actor-repository.js";
 import { FollowRepository } from "./infrastructure/follow-repository.js";
+import { LikeRepository } from "./infrastructure/like-repository.js";
 import { PostRepository } from "./infrastructure/post-repository.js";
 import { ProfileRecordFetcher } from "./infrastructure/profile-record-fetcher.js";
 import { ProfileRepository } from "./infrastructure/profile-repository.js";
@@ -60,6 +62,7 @@ createInjector()
   .provideClass("postRepository", PostRepository)
   .provideClass("recordRepository", RecordRepository)
   .provideClass("followRepository", FollowRepository)
+  .provideClass("likeRepository", LikeRepository)
   .provideClass("subscriptionRepository", SubscriptionRepository)
   // application(service)
   .provideClass("resolveDidService", ResolveDidService)
@@ -69,6 +72,7 @@ createInjector()
   .provideClass("indexPostService", IndexPostService)
   .provideClass("indexActorService", IndexActorService)
   .provideClass("indexFollowService", IndexFollowService)
+  .provideClass("indexLikeService", IndexLikeService)
   .provideClass("indexSubscriptionService", IndexSubscriptionService)
   .provideClass("indexCommitService", IndexCommitService)
   // application(use-case)

--- a/packages/client/src/server.ts
+++ b/packages/client/src/server.ts
@@ -8,6 +8,7 @@ export * as AppBskyActorDefs from "./generated/api/types/app/bsky/actor/defs";
 export * as AppBskyActorProfile from "./generated/api/types/app/bsky/actor/profile";
 export * as AppBskyEmbedImages from "./generated/server/types/app/bsky/embed/images";
 export * as AppBskyEmbedExternal from "./generated/server/types/app/bsky/embed/external";
+export * as AppBskyFeedLike from "./generated/api/types/app/bsky/feed/like";
 export * as AppBskyFeedPost from "./generated/api/types/app/bsky/feed/post";
 export * as AppBskyGraphFollow from "./generated/api/types/app/bsky/graph/follow";
 export * as DevMkizkaTestSubscription from "./generated/api/types/dev/mkizka/test/subscription";

--- a/packages/common/src/domain.ts
+++ b/packages/common/src/domain.ts
@@ -5,6 +5,7 @@ export * from "./lib/domain/interfaces/job-queue.js";
 export * from "./lib/domain/interfaces/logger.js";
 export * from "./lib/domain/interfaces/metric.js";
 export * from "./lib/domain/interfaces/transaction.js";
+export * from "./lib/domain/like.js";
 export * from "./lib/domain/post/embed-external.js";
 export * from "./lib/domain/post/embed-images.js";
 export * from "./lib/domain/post/post.js";

--- a/packages/common/src/lib/domain/like.ts
+++ b/packages/common/src/lib/domain/like.ts
@@ -1,0 +1,43 @@
+import { asDid, type Did } from "@atproto/did";
+import { AtUri } from "@atproto/syntax";
+
+import type { Record } from "./record.js";
+
+type LikeParams = {
+  uri: AtUri | string;
+  cid: string;
+  actorDid: string;
+  subjectUri: string;
+  subjectCid: string;
+  createdAt: Date;
+};
+
+export class Like {
+  readonly uri: AtUri;
+  readonly cid: string;
+  readonly actorDid: Did;
+  readonly subjectUri: AtUri;
+  readonly subjectCid: string;
+  readonly createdAt: Date;
+
+  constructor(params: LikeParams) {
+    this.uri = new AtUri(params.uri.toString());
+    this.cid = params.cid;
+    this.actorDid = asDid(params.actorDid);
+    this.subjectUri = new AtUri(params.subjectUri);
+    this.subjectCid = params.subjectCid;
+    this.createdAt = params.createdAt;
+  }
+
+  static from(record: Record) {
+    const parsed = record.validate("app.bsky.feed.like");
+    return new Like({
+      uri: record.uri,
+      cid: record.cid,
+      actorDid: record.actorDid,
+      subjectUri: parsed.subject.uri,
+      subjectCid: parsed.subject.cid,
+      createdAt: new Date(parsed.createdAt),
+    });
+  }
+}

--- a/packages/common/src/lib/utils/collection.ts
+++ b/packages/common/src/lib/utils/collection.ts
@@ -1,5 +1,6 @@
 import type {
   AppBskyActorProfile,
+  AppBskyFeedLike,
   AppBskyFeedPost,
   AppBskyGraphFollow,
   DevMkizkaTestSubscription,
@@ -7,6 +8,7 @@ import type {
 
 export type SupportedCollectionMap = {
   "app.bsky.actor.profile": AppBskyActorProfile.Record;
+  "app.bsky.feed.like": AppBskyFeedLike.Record;
   "app.bsky.feed.post": AppBskyFeedPost.Record;
   "app.bsky.graph.follow": AppBskyGraphFollow.Record;
   "dev.mkizka.test.subscription": DevMkizkaTestSubscription.Record;
@@ -16,6 +18,7 @@ export type SupportedCollection = keyof SupportedCollectionMap;
 
 export const SUPPORTED_COLLECTIONS = [
   "app.bsky.actor.profile",
+  "app.bsky.feed.like",
   "app.bsky.feed.post",
   "app.bsky.graph.follow",
   "dev.mkizka.test.subscription",

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -126,6 +126,27 @@ export const subscriptions = pgTable("subscriptions", {
   indexedAt: timestamp().defaultNow(),
 });
 
+export const likes = pgTable(
+  "likes",
+  {
+    uri: varchar({ length: 256 })
+      .primaryKey()
+      .references(() => records.uri, { onDelete: "cascade" }),
+    cid: varchar({ length: 256 }).notNull(),
+    actorDid: varchar({ length: 256 })
+      .notNull()
+      .references(() => actors.did),
+    subjectUri: varchar({ length: 256 }).notNull(),
+    subjectCid: varchar({ length: 256 }).notNull(),
+    createdAt: timestamp().notNull(),
+    indexedAt: timestamp().defaultNow(),
+    sortAt: timestamp()
+      .generatedAlwaysAs(sql`least("created_at", "indexed_at")`)
+      .notNull(),
+  },
+  (table) => [index("likes_sort_at_idx").on(table.sortAt)],
+);
+
 export const postEmbedImages = pgTable("post_embed_images", {
   postUri: varchar({ length: 256 })
     .notNull()


### PR DESCRIPTION
## Summary
- SUPPORTED_COLLECTIONSにapp.bsky.feed.likeを追加
- likesテーブルをschema.tsに追加し、subjectUriとsubjectCidを含む構造で定義
- Likeドメインモデルを作成し、strongRef構造を適切に処理

## Test plan
- [x] 型チェックが通ることを確認
- [x] フォーマットが正しく適用されることを確認
- [ ] likeレコードがJetstreamから流れてきた際に適切にインデックスされることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)