### PR TITLE
fix: TimelineHeaderContainerのimportパスをparts/からblocks/に修正

### DIFF
--- a/apps/subscope/app/features/timeline/pages/timeline.tsx
+++ b/apps/subscope/app/features/timeline/pages/timeline.tsx
@@ -1,6 +1,6 @@
 import { AppLayout } from "@/app/components/layout";
 import { TimelineFeedContainer } from "@/app/features/timeline/blocks/timeline-feed-container";
-import { TimelineHeaderContainer } from "@/app/features/timeline/parts/timeline-header-container";
+import { TimelineHeaderContainer } from "@/app/features/timeline/blocks/timeline-header-container";
 
 export function TimelinePage() {
   return (


### PR DESCRIPTION
TimelineHeaderContainerはblocksディレクトリに存在するため、
importパスを正しいパスに修正。

https://claude.ai/code/session_012NbaenN4JS3NJG1YyYs347