### PR TITLE
refactor: envの直接参照をDIに置き換え

### DIFF
--- a/apps/appview/src/appview.ts
+++ b/apps/appview/src/appview.ts
@@ -90,6 +90,7 @@ import { GetTimeline } from "./presentation/routes/app/bsky/feed/getTimeline.js"
 import { SearchPosts } from "./presentation/routes/app/bsky/feed/searchPosts.js";
 import { GetFollowers } from "./presentation/routes/app/bsky/graph/getFollowers.js";
 import { GetFollows } from "./presentation/routes/app/bsky/graph/getFollows.js";
+import { healthRouterFactory } from "./presentation/routes/health.js";
 import { CreateInviteCode } from "./presentation/routes/me/subsco/admin/createInviteCode.js";
 import { DeleteInviteCode } from "./presentation/routes/me/subsco/admin/deleteInviteCode.js";
 import { GetInviteCodes } from "./presentation/routes/me/subsco/admin/getInviteCodes.js";
@@ -100,18 +101,22 @@ import { GetSetupStatus } from "./presentation/routes/me/subsco/server/getSetupS
 import { GetSubscriptionStatus } from "./presentation/routes/me/subsco/sync/getSubscriptionStatus.js";
 import { SubscribeServer } from "./presentation/routes/me/subsco/sync/subscribeServer.js";
 import { UnsubscribeServer } from "./presentation/routes/me/subsco/sync/unsubscribeServer.js";
+import { wellKnownRouterFactory } from "./presentation/routes/well-known.js";
 import { xrpcRouterFactory } from "./presentation/routes/xrpc.js";
 import { AppViewServer } from "./presentation/server.js";
 import { env } from "./shared/env.js";
 
 createInjector()
   // envs
+  .provideValue("nodeEnv", env.NODE_ENV)
   .provideValue("logLevel", env.LOG_LEVEL)
+  .provideValue("port", env.PORT)
   .provideValue("plcUrl", env.PLC_URL)
   .provideValue("redisUrl", env.REDIS_URL)
   .provideValue("databaseUrl", env.DATABASE_URL)
   .provideValue("publicUrl", env.PUBLIC_URL)
   .provideValue("blobProxyUrl", env.BLOB_PROXY_URL)
+  .provideValue("serviceDid", env.SERVICE_DID)
   // infrastructure
   .provideClass("loggerManager", LoggerManager)
   .provideClass("metricReporter", MetricReporter)
@@ -213,6 +218,8 @@ createInjector()
   .provideClass("getSubscriptionStatus", GetSubscriptionStatus)
   .provideClass("subscribeServer", SubscribeServer)
   .provideClass("unsubscribeServer", UnsubscribeServer)
+  .provideFactory("healthRouter", healthRouterFactory)
+  .provideFactory("wellKnownRouter", wellKnownRouterFactory)
   .provideFactory("xrpcRouter", xrpcRouterFactory)
   // bootstrap
   .injectClass(AppViewServer)

--- a/apps/appview/src/infrastructure/token-verifier/token-verifier.ts
+++ b/apps/appview/src/infrastructure/token-verifier/token-verifier.ts
@@ -3,11 +3,13 @@ import { verifyJwt } from "@atproto/xrpc-server";
 import type { IDidResolver } from "@repo/common/domain";
 
 import type { ITokenVerifier } from "../../application/interfaces/token-verifier.js";
-import { env } from "../../shared/env.js";
 
 export class TokenVerifier implements ITokenVerifier {
-  constructor(private readonly didResolver: IDidResolver) {}
-  static inject = ["didResolver"] as const;
+  constructor(
+    private readonly didResolver: IDidResolver,
+    private readonly serviceDid: string,
+  ) {}
+  static inject = ["didResolver", "serviceDid"] as const;
 
   async verify(params: { token: string; nsid: string }) {
     const getSigninKey = async (did: string) => {
@@ -16,7 +18,7 @@ export class TokenVerifier implements ITokenVerifier {
     };
     const payload = await verifyJwt(
       params.token,
-      env.SERVICE_DID, // TODO: 引数から受け取る
+      this.serviceDid,
       params.nsid,
       getSigninKey,
     );

--- a/apps/appview/src/presentation/routes/health.ts
+++ b/apps/appview/src/presentation/routes/health.ts
@@ -1,25 +1,28 @@
 import { Router } from "express";
 
-import { env } from "../../shared/env.js";
-
-const healthRouter: Router = Router();
-
-const keyof = <T extends Record<string, unknown>, K extends keyof T>(
-  obj: T,
-  keys: K[],
+export const healthRouterFactory = (
+  nodeEnv: string,
+  logLevel: string,
+  port: number,
+  publicUrl: string,
 ) => {
-  return keys.reduce<Pick<T, K>>((acc, key) => {
-    acc[key] = obj[key];
-    return acc;
-    // @ts-expect-error
-  }, {});
-};
-
-healthRouter.get("/health", (_req, res) => {
-  res.json({
-    status: "ok",
-    env: keyof(env, ["NODE_ENV", "LOG_LEVEL", "PORT", "PUBLIC_URL"]),
+  const healthRouter = Router();
+  healthRouter.get("/health", (_req, res) => {
+    res.json({
+      status: "ok",
+      env: {
+        NODE_ENV: nodeEnv,
+        LOG_LEVEL: logLevel,
+        PORT: port,
+        PUBLIC_URL: publicUrl,
+      },
+    });
   });
-});
-
-export { healthRouter };
+  return healthRouter;
+};
+healthRouterFactory.inject = [
+  "nodeEnv",
+  "logLevel",
+  "port",
+  "publicUrl",
+] as const;

--- a/apps/appview/src/presentation/routes/well-known.ts
+++ b/apps/appview/src/presentation/routes/well-known.ts
@@ -1,21 +1,23 @@
 import { Router } from "express";
 
-import { env } from "../../shared/env.js";
-
-const wellKnownRouter: Router = Router();
-
-wellKnownRouter.get("/.well-known/did.json", (_req, res) => {
-  res.json({
-    "@context": ["https://www.w3.org/ns/did/v1"],
-    id: env.SERVICE_DID,
-    service: [
-      {
-        id: `#bsky_appview`,
-        type: "BskyAppView",
-        serviceEndpoint: env.PUBLIC_URL,
-      },
-    ],
+export const wellKnownRouterFactory = (
+  serviceDid: string,
+  publicUrl: string,
+) => {
+  const wellKnownRouter = Router();
+  wellKnownRouter.get("/.well-known/did.json", (_req, res) => {
+    res.json({
+      "@context": ["https://www.w3.org/ns/did/v1"],
+      id: serviceDid,
+      service: [
+        {
+          id: `#bsky_appview`,
+          type: "BskyAppView",
+          serviceEndpoint: publicUrl,
+        },
+      ],
+    });
   });
-});
-
-export { wellKnownRouter };
+  return wellKnownRouter;
+};
+wellKnownRouterFactory.inject = ["serviceDid", "publicUrl"] as const;

--- a/apps/appview/src/presentation/server.ts
+++ b/apps/appview/src/presentation/server.ts
@@ -4,15 +4,17 @@ import type { Router } from "express";
 import express from "express";
 import promBundle from "express-prom-bundle";
 
-import { env } from "../shared/env.js";
-import { healthRouter } from "./routes/health.js";
-import { wellKnownRouter } from "./routes/well-known.js";
-
 export class AppViewServer {
   private readonly app: express.Express;
   private readonly logger: Logger;
 
-  constructor(loggerManager: ILoggerManager, xrpcRouter: Router) {
+  constructor(
+    loggerManager: ILoggerManager,
+    private readonly port: number,
+    healthRouter: Router,
+    wellKnownRouter: Router,
+    xrpcRouter: Router,
+  ) {
     this.logger = loggerManager.createLogger("AppViewServer");
     this.app = express();
     this.app.use(loggingMiddleware(this.logger));
@@ -21,11 +23,17 @@ export class AppViewServer {
     this.app.use(wellKnownRouter);
     this.app.use(xrpcRouter);
   }
-  static inject = ["loggerManager", "xrpcRouter"] as const;
+  static inject = [
+    "loggerManager",
+    "port",
+    "healthRouter",
+    "wellKnownRouter",
+    "xrpcRouter",
+  ] as const;
 
   start() {
-    this.app.listen(env.PORT, () => {
-      this.logger.info(`AppView server listening on port ${env.PORT}`);
+    this.app.listen(this.port, () => {
+      this.logger.info(`AppView server listening on port ${this.port}`);
     });
   }
 }

--- a/apps/blob-proxy/src/blob-proxy.ts
+++ b/apps/blob-proxy/src/blob-proxy.ts
@@ -19,11 +19,14 @@ import { CronTaskScheduler } from "./infrastructure/cron-task-scheduler.js";
 import { ImageDiskStorage } from "./infrastructure/image-disk-storage.js";
 import { ImageResizer } from "./infrastructure/image-resizer.js";
 import { imagesRouterFactory } from "./presentation/images.js";
+import { healthRouterFactory } from "./presentation/routes/health.js";
 import { BlobProxyServer } from "./presentation/server.js";
 import { env } from "./shared/env.js";
 
 createInjector()
   // envs
+  .provideValue("nodeEnv", env.NODE_ENV)
+  .provideValue("port", env.PORT)
   .provideValue("logLevel", env.LOG_LEVEL)
   .provideValue("plcUrl", env.PLC_URL)
   .provideValue("redisUrl", env.REDIS_URL)
@@ -51,5 +54,6 @@ createInjector()
   .provideClass("imageProxyUseCase", ImageProxyUseCase)
   // presentation
   .provideFactory("imagesRouter", imagesRouterFactory)
+  .provideFactory("healthRouter", healthRouterFactory)
   .injectClass(BlobProxyServer)
   .start();

--- a/apps/blob-proxy/src/presentation/routes/health.ts
+++ b/apps/blob-proxy/src/presentation/routes/health.ts
@@ -1,25 +1,21 @@
 import { Router } from "express";
 
-import { env } from "../../shared/env.js";
-
-const healthRouter = Router();
-
-const keyof = <T extends Record<string, unknown>, K extends keyof T>(
-  obj: T,
-  keys: K[],
+export const healthRouterFactory = (
+  nodeEnv: string,
+  logLevel: string,
+  port: number,
 ) => {
-  return keys.reduce<Pick<T, K>>((acc, key) => {
-    acc[key] = obj[key];
-    return acc;
-    // @ts-expect-error
-  }, {});
-};
-
-healthRouter.get("/health", (_, res) => {
-  res.json({
-    status: "ok",
-    env: keyof(env, ["NODE_ENV", "LOG_LEVEL", "PORT"]),
+  const healthRouter = Router();
+  healthRouter.get("/health", (_, res) => {
+    res.json({
+      status: "ok",
+      env: {
+        NODE_ENV: nodeEnv,
+        LOG_LEVEL: logLevel,
+        PORT: port,
+      },
+    });
   });
-});
-
-export { healthRouter };
+  return healthRouter;
+};
+healthRouterFactory.inject = ["nodeEnv", "logLevel", "port"] as const;

--- a/apps/blob-proxy/src/presentation/server.ts
+++ b/apps/blob-proxy/src/presentation/server.ts
@@ -5,8 +5,6 @@ import express from "express";
 import promBundle from "express-prom-bundle";
 
 import type { CacheCleanupScheduler } from "../application/services/cache-cleanup-scheduler.js";
-import { env } from "../shared/env.js";
-import { healthRouter } from "./routes/health.js";
 
 export class BlobProxyServer {
   private readonly app: express.Express;
@@ -14,7 +12,9 @@ export class BlobProxyServer {
 
   constructor(
     loggerManager: ILoggerManager,
+    private readonly port: number,
     imagesRouter: Router,
+    healthRouter: Router,
     private readonly cacheCleanupScheduler: CacheCleanupScheduler,
   ) {
     this.logger = loggerManager.createLogger("BlobProxyServer");
@@ -26,13 +26,15 @@ export class BlobProxyServer {
   }
   static inject = [
     "loggerManager",
+    "port",
     "imagesRouter",
+    "healthRouter",
     "cacheCleanupScheduler",
   ] as const;
 
   start() {
-    this.app.listen(env.PORT, () => {
-      this.logger.info(`Blob proxy server listening on port ${env.PORT}`);
+    this.app.listen(this.port, () => {
+      this.logger.info(`Blob proxy server listening on port ${this.port}`);
       this.cacheCleanupScheduler.start();
     });
   }

--- a/apps/ingester/src/ingester.ts
+++ b/apps/ingester/src/ingester.ts
@@ -8,6 +8,7 @@ import { createInjector } from "typed-inject";
 import { HandleCommitUseCase } from "./application/handle-commit-use-case.js";
 import { HandleIdentityUseCase } from "./application/handle-identity-use-case.js";
 import { LabelIngester } from "./presentation/label.js";
+import { healthRouterFactory } from "./presentation/routes/health.js";
 import { metricsRouterFactory } from "./presentation/routes/metrics.js";
 import { IngesterServer } from "./presentation/server.js";
 import { TapIngester } from "./presentation/tap.js";
@@ -15,8 +16,13 @@ import { env } from "./shared/env.js";
 
 createInjector()
   // envs
+  .provideValue("nodeEnv", env.NODE_ENV)
+  .provideValue("port", env.PORT)
   .provideValue("logLevel", env.LOG_LEVEL)
   .provideValue("redisUrl", env.REDIS_URL)
+  .provideValue("tapUrl", env.TAP_URL)
+  .provideValue("moderationUrl", env.MODERATION_URL)
+  .provideValue("disableIngester", env.DISABLE_INGESTER)
   // infrastructure
   .provideClass("loggerManager", LoggerManager)
   .provideClass("jobQueue", JobQueue)
@@ -25,6 +31,7 @@ createInjector()
   .provideClass("handleIdentityUseCase", HandleIdentityUseCase)
   .provideClass("handleCommitUseCase", HandleCommitUseCase)
   // presentation
+  .provideFactory("healthRouter", healthRouterFactory)
   .provideFactory("metricsRouter", metricsRouterFactory)
   .provideClass("tapIngester", TapIngester)
   .provideClass("labelIngester", LabelIngester)

--- a/apps/ingester/src/presentation/label.ts
+++ b/apps/ingester/src/presentation/label.ts
@@ -2,14 +2,15 @@ import { Subscription } from "@atproto/xrpc-server";
 import { ComAtprotoLabelSubscribeLabels } from "@repo/client/api";
 import type { IMetricReporter } from "@repo/common/domain";
 
-import { env } from "../shared/env.js";
-
 export class LabelIngester {
   private readonly subscription;
 
-  constructor(private readonly metricReporter: IMetricReporter) {
+  constructor(
+    private readonly metricReporter: IMetricReporter,
+    moderationUrl: string,
+  ) {
     this.subscription = new Subscription({
-      service: env.MODERATION_URL,
+      service: moderationUrl,
       method: "com.atproto.label.subscribeLabels",
       validate: (obj: unknown) => {
         const parsedInfo = ComAtprotoLabelSubscribeLabels.validateInfo(obj);
@@ -24,7 +25,7 @@ export class LabelIngester {
       },
     });
   }
-  static inject = ["metricReporter"] as const;
+  static inject = ["metricReporter", "moderationUrl"] as const;
 
   async start() {
     for await (const message of this.subscription) {

--- a/apps/ingester/src/presentation/routes/health.ts
+++ b/apps/ingester/src/presentation/routes/health.ts
@@ -1,25 +1,21 @@
 import { Router } from "express";
 
-import { env } from "../../shared/env.js";
-
-const healthRouter = Router();
-
-const keyof = <T extends Record<string, unknown>, K extends keyof T>(
-  obj: T,
-  keys: K[],
+export const healthRouterFactory = (
+  nodeEnv: string,
+  logLevel: string,
+  port: number,
 ) => {
-  return keys.reduce<Pick<T, K>>((acc, key) => {
-    acc[key] = obj[key];
-    return acc;
-    // @ts-expect-error
-  }, {});
-};
-
-healthRouter.get("/health", (_, res) => {
-  res.json({
-    status: "ok",
-    env: keyof(env, ["NODE_ENV", "LOG_LEVEL", "PORT"]),
+  const healthRouter = Router();
+  healthRouter.get("/health", (_, res) => {
+    res.json({
+      status: "ok",
+      env: {
+        NODE_ENV: nodeEnv,
+        LOG_LEVEL: logLevel,
+        PORT: port,
+      },
+    });
   });
-});
-
-export { healthRouter };
+  return healthRouter;
+};
+healthRouterFactory.inject = ["nodeEnv", "logLevel", "port"] as const;

--- a/apps/ingester/src/presentation/server.ts
+++ b/apps/ingester/src/presentation/server.ts
@@ -3,9 +3,7 @@ import { loggingMiddleware } from "@repo/common/utils";
 import type { Router } from "express";
 import express from "express";
 
-import { env } from "../shared/env.js";
 import type { LabelIngester } from "./label.js";
-import { healthRouter } from "./routes/health.js";
 import type { TapIngester } from "./tap.js";
 
 export class IngesterServer {
@@ -14,7 +12,10 @@ export class IngesterServer {
 
   constructor(
     loggerManager: ILoggerManager,
+    private readonly port: number,
+    private readonly disableIngester: boolean,
     metricsRouter: Router,
+    healthRouter: Router,
     private readonly tapIngester: TapIngester,
     private readonly labelIngester: LabelIngester,
   ) {
@@ -26,15 +27,18 @@ export class IngesterServer {
   }
   static inject = [
     "loggerManager",
+    "port",
+    "disableIngester",
     "metricsRouter",
+    "healthRouter",
     "tapIngester",
     "labelIngester",
   ] as const;
 
   start() {
-    this.app.listen(env.PORT, () => {
-      this.logger.info(`Ingester server listening on port ${env.PORT}`);
-      if (!env.DISABLE_INGESTER) {
+    this.app.listen(this.port, () => {
+      this.logger.info(`Ingester server listening on port ${this.port}`);
+      if (!this.disableIngester) {
         this.tapIngester.start().catch((err: unknown) => {
           this.logger.error({ err }, "Tap ingester threw");
         });

--- a/apps/ingester/src/presentation/tap.ts
+++ b/apps/ingester/src/presentation/tap.ts
@@ -10,7 +10,6 @@ import { isSupportedCollection } from "@repo/common/utils";
 
 import type { HandleCommitUseCase } from "../application/handle-commit-use-case.js";
 import type { HandleIdentityUseCase } from "../application/handle-identity-use-case.js";
-import { env } from "../shared/env.js";
 
 export class TapIngester {
   private readonly tap;
@@ -19,11 +18,12 @@ export class TapIngester {
 
   constructor(
     loggerManager: ILoggerManager,
+    private readonly tapUrl: string,
     private readonly handleCommitUseCase: HandleCommitUseCase,
     private readonly handleIdentityUseCase: HandleIdentityUseCase,
   ) {
     this.logger = loggerManager.createLogger("TapIngester");
-    this.tap = new Tap(env.TAP_URL);
+    this.tap = new Tap(this.tapUrl);
     this.indexer = new SimpleIndexer();
 
     this.indexer.record(async (event) => {
@@ -48,6 +48,7 @@ export class TapIngester {
 
   static inject = [
     "loggerManager",
+    "tapUrl",
     "handleCommitUseCase",
     "handleIdentityUseCase",
   ] as const;
@@ -94,7 +95,7 @@ export class TapIngester {
       heartbeatIntervalMs: 60_000,
     });
 
-    this.logger.info(`Tap connection starting at ${env.TAP_URL}`);
+    this.logger.info(`Tap connection starting at ${this.tapUrl}`);
 
     await channel.start();
   }

--- a/apps/worker/src/presentation/routes/health.ts
+++ b/apps/worker/src/presentation/routes/health.ts
@@ -1,25 +1,21 @@
 import { Router } from "express";
 
-import { env } from "../../shared/env.js";
-
-const healthRouter = Router();
-
-const keyof = <T extends Record<string, unknown>, K extends keyof T>(
-  obj: T,
-  keys: K[],
+export const healthRouterFactory = (
+  nodeEnv: string,
+  logLevel: string,
+  port: number,
 ) => {
-  return keys.reduce<Pick<T, K>>((acc, key) => {
-    acc[key] = obj[key];
-    return acc;
-    // @ts-expect-error
-  }, {});
-};
-
-healthRouter.get("/health", (_, res) => {
-  res.json({
-    status: "ok",
-    env: keyof(env, ["NODE_ENV", "LOG_LEVEL", "PORT"]),
+  const healthRouter = Router();
+  healthRouter.get("/health", (_, res) => {
+    res.json({
+      status: "ok",
+      env: {
+        NODE_ENV: nodeEnv,
+        LOG_LEVEL: logLevel,
+        PORT: port,
+      },
+    });
   });
-});
-
-export { healthRouter };
+  return healthRouter;
+};
+healthRouterFactory.inject = ["nodeEnv", "logLevel", "port"] as const;

--- a/apps/worker/src/presentation/server.ts
+++ b/apps/worker/src/presentation/server.ts
@@ -2,11 +2,10 @@ import type { Server } from "node:http";
 
 import type { ILoggerManager, Logger } from "@repo/common/domain";
 import { loggingMiddleware } from "@repo/common/utils";
+import type { Router } from "express";
 import express from "express";
 import promBundle from "express-prom-bundle";
 
-import { env } from "../shared/env.js";
-import { healthRouter } from "./routes/health.js";
 import type { SyncWorker } from "./worker.js";
 
 export class WorkerServer {
@@ -16,6 +15,8 @@ export class WorkerServer {
 
   constructor(
     loggerManager: ILoggerManager,
+    private readonly port: number,
+    healthRouter: Router,
     private readonly syncWorker: SyncWorker,
   ) {
     this.logger = loggerManager.createLogger("WorkerServer");
@@ -24,11 +25,16 @@ export class WorkerServer {
     this.app.use(promBundle({ includeMethod: true }));
     this.app.use(healthRouter);
   }
-  static inject = ["loggerManager", "syncWorker"] as const;
+  static inject = [
+    "loggerManager",
+    "port",
+    "healthRouter",
+    "syncWorker",
+  ] as const;
 
   start() {
-    this.server = this.app.listen(env.PORT, async () => {
-      this.logger.info(`Worker server listening on port ${env.PORT}`);
+    this.server = this.app.listen(this.port, async () => {
+      this.logger.info(`Worker server listening on port ${this.port}`);
       await this.syncWorker.start();
     });
 

--- a/apps/worker/src/presentation/worker.ts
+++ b/apps/worker/src/presentation/worker.ts
@@ -14,7 +14,6 @@ import { indexCommitCommandFactory } from "../application/use-cases/commit/index
 import type { IndexCommitUseCase } from "../application/use-cases/commit/index-commit-use-case.js";
 import { upsertIdentityCommandFactory } from "../application/use-cases/identity/upsert-identity-command.js";
 import type { UpsertIdentityUseCase } from "../application/use-cases/identity/upsert-identity-use-case.js";
-import { env } from "../shared/env.js";
 import { createJobLogger } from "../shared/job.js";
 
 const SECONDS = 1000;
@@ -39,27 +38,12 @@ const backoffStrategy: BackoffStrategy = (attemptsMade) => {
   return delay;
 };
 
-const createWorker = <T extends keyof JobData>(
-  name: T,
-  process: Processor<JobData[T], void>,
-  options?: Omit<WorkerOptions, "connection" | "autorun">,
-) => {
-  return new Worker<JobData[T]>(name, process, {
-    autorun: false,
-    connection: {
-      url: env.REDIS_URL,
-    },
-    settings: {
-      backoffStrategy,
-    },
-    ...options,
-  });
-};
-
 export class SyncWorker {
   private readonly workers: Worker[];
 
   constructor(
+    redisUrl: string,
+    commitWorkerConcurrency: number,
     upsertIdentityUseCase: UpsertIdentityUseCase,
     indexCommitUseCase: IndexCommitUseCase,
     resolveDidUseCase: ResolveDidUseCase,
@@ -69,6 +53,23 @@ export class SyncWorker {
     addTapRepoUseCase: AddTapRepoUseCase,
     removeTapRepoUseCase: RemoveTapRepoUseCase,
   ) {
+    const createWorker = <T extends keyof JobData>(
+      name: T,
+      process: Processor<JobData[T], void>,
+      options?: Omit<WorkerOptions, "connection" | "autorun">,
+    ) => {
+      return new Worker<JobData[T]>(name, process, {
+        autorun: false,
+        connection: {
+          url: redisUrl,
+        },
+        settings: {
+          backoffStrategy,
+        },
+        ...options,
+      });
+    };
+
     this.workers = [
       createWorker("identity", async (job) => {
         const command = upsertIdentityCommandFactory(job.data);
@@ -84,7 +85,7 @@ export class SyncWorker {
           await indexCommitUseCase.execute(command);
         },
         {
-          concurrency: env.COMMIT_WORKER_CONCURRENCY,
+          concurrency: commitWorkerConcurrency,
         },
       ),
       createWorker(
@@ -139,6 +140,8 @@ export class SyncWorker {
     ];
   }
   static inject = [
+    "redisUrl",
+    "commitWorkerConcurrency",
     "upsertIdentityUseCase",
     "indexCommitUseCase",
     "resolveDidUseCase",

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -42,18 +42,21 @@ import { ProfileRepository } from "./infrastructure/repositories/profile-reposit
 import { RecordRepository } from "./infrastructure/repositories/record-repository/record-repository.js";
 import { RepostRepository } from "./infrastructure/repositories/repost-repository/repost-repository.js";
 import { SubscriptionRepository } from "./infrastructure/repositories/subscription-repository/subscription-repository.js";
+import { healthRouterFactory } from "./presentation/routes/health.js";
 import { WorkerServer } from "./presentation/server.js";
 import { SyncWorker } from "./presentation/worker.js";
 import { env } from "./shared/env.js";
 
 createInjector()
   // envs
+  .provideValue("nodeEnv", env.NODE_ENV)
+  .provideValue("port", env.PORT)
   .provideValue("databaseUrl", env.DATABASE_URL)
   .provideValue("redisUrl", env.REDIS_URL)
   .provideValue("logLevel", env.LOG_LEVEL)
-  .provideValue("redisUrl", env.REDIS_URL)
   .provideValue("plcUrl", env.PLC_URL)
   .provideValue("tapUrl", env.TAP_URL)
+  .provideValue("commitWorkerConcurrency", env.COMMIT_WORKER_CONCURRENCY)
   // infrastructure
   .provideClass("loggerManager", LoggerManager)
   .provideClass("tapClient", TapClient)
@@ -99,5 +102,6 @@ createInjector()
   .provideClass("removeTapRepoUseCase", RemoveTapRepoUseCase)
   .provideClass("syncWorker", SyncWorker)
   // presentation
+  .provideFactory("healthRouter", healthRouterFactory)
   .injectClass(WorkerServer)
   .start();


### PR DESCRIPTION
各typed-injectアプリ(appview/worker/ingester/blob-proxy)で、
composition root以外がshared/envを直接importしていた箇所を、
DIコンテナ経由の注入に置き換えた。

- env値はcomposition rootでのみ読み込み、provideValueで注入
- health/well-knownルーターをfactory化してDIで提供
- 各classはport/serviceDid/tapUrl等を引数で受け取るよう変更

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01S88pfTJzLRUQrZZGzdySWq